### PR TITLE
Add dates to post overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
       <article class="post">
 
         <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
-
+        <div class="date">{{ post.date | date: '%B %e, %Y' }}</div>
         <div class="entry">
           {{ post.excerpt }}
         </div>


### PR DESCRIPTION
Hi Jesse,

I like to see dates of blog posts without having to click to a post :-)
I didn't run Jekyll locally so no guarantees that this works.

Thanks for lazydocker and lazygit!