### PR TITLE
Set headers to h2 for list of posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,18 @@ layout: default
 ---
 
 <div class="posts">
-    {% for post in site.posts %}
+  {% for post in site.posts %}
     {% if post.unlisted != true %}
-    <article class="post">
+      <article class="post">
 
         <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
 
         <div class="entry">
-            {{ post.excerpt }}
+          {{ post.excerpt }}
         </div>
 
         <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
-    </article>
+      </article>
     {% endif %}
-    {% endfor %}
+  {% endfor %}
 </div>

--- a/index.html
+++ b/index.html
@@ -3,18 +3,18 @@ layout: default
 ---
 
 <div class="posts">
-  {% for post in site.posts %}
+    {% for post in site.posts %}
     {% if post.unlisted != true %}
-      <article class="post">
+    <article class="post">
 
-        <h1><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h1>
+        <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
 
         <div class="entry">
-          {{ post.excerpt }}
+            {{ post.excerpt }}
         </div>
 
         <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
-      </article>
+    </article>
     {% endif %}
-  {% endfor %}
+    {% endfor %}
 </div>


### PR DESCRIPTION
Hi Jesse,

In the overview of posts I saw you used `<h1>`s. I've always learned that a page should have exactly one of those.
I didn't run Jekyll locally so no guarantees that this works.

Thanks for lazydocker and lazygit!